### PR TITLE
Add migration to add language field to articles collection

### DIFF
--- a/02-add-language-to-articles-migration.py
+++ b/02-add-language-to-articles-migration.py
@@ -1,0 +1,4 @@
+
+from database import database
+
+database.articles.update_many({}, [{'$set': {'language': 'en'}}])


### PR DESCRIPTION
Adds a language field to the articles collection, defaulting to `en`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented a database update to set the language field to 'en' for all existing articles, ensuring consistency across the content.
  
- **Bug Fixes**
	- Corrected the language attribute for articles in the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->